### PR TITLE
Properly handle UTF8 characters in length measurements

### DIFF
--- a/table.go
+++ b/table.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 // Alignment represents the supported cell content alignment modes.
@@ -265,5 +266,5 @@ func (t *Table) groupWidths(colWidths []int) (groupWidths []int, adjustedColWidt
 
 // Measure string length excluding any Ansi color escape codes.
 func measure(val string) int {
-	return len(ansiEscapeRegex.ReplaceAllString(val, ""))
+	return utf8.RuneCountInString(ansiEscapeRegex.ReplaceAllString(val, ""))
 }

--- a/table_test.go
+++ b/table_test.go
@@ -206,6 +206,38 @@ func TestHeaderGroups(t *testing.T) {
 	}
 }
 
+func TestUTF8Handling(t *testing.T) {
+	expOutput := `+-------+-------+
+| 1     | 2     |
++-------+-------+
+| ▲ 123 | 123 ▾ |
+| > 123 | 123 < |
++-------+-------+
+`
+
+	var buf bytes.Buffer
+	table := New(2)
+	table.SetHeader(0, "1", AlignLeft)
+	table.SetHeader(1, "2", AlignLeft)
+	table.SetPadding(1)
+	table.Append(
+		[]string{"▲ 123", "123 ▾"},
+		[]string{"> 123", "123 <"},
+	)
+
+	buf.Reset()
+	table.Write(&buf, PreserveAnsi)
+	tableOutput := buf.String()
+
+	if tableOutput != expOutput {
+		t.Errorf(
+			"expected output to be: \n%s\n got:\n%s\n",
+			indent(expOutput, 2),
+			indent(tableOutput, 2),
+		)
+	}
+}
+
 func indent(s string, pad int) string {
 	return regexp.MustCompile("(?m)^").ReplaceAllString(s, strings.Repeat(" ", pad))
 }


### PR DESCRIPTION
When measuring strings containing UTF8 characters we need to count the
number of runes in the string using utf8.RuneCountInString(str) instead of
len(str)